### PR TITLE
auto detect client for google ads

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -155,7 +155,6 @@ function onAuthedReq(endpoint, cb, includeLocations = false) {
     const client = await getClientFromUrn(data.clientUrn)
     const locations = await getLocations(client.urn)
     const { locationUrn } = data
-    console.log(includeLocations)
     if (includeLocations) {
       const selectedLocations = locations.filter(l => l.urn === locationUrn)
       cb({ client, locations, selectedLocations })

--- a/src/background.js
+++ b/src/background.js
@@ -46,7 +46,9 @@ async function onMessage(req, sender, res) {
     const { manual } = req
     await autoDetectClientLocation(req.url, res, manual)
   } else if (req.msg === 'google-ads') {
-    const accountId = req.data.codeAccount.replace(/-/g, '')
+    const accountId = req.data.customerId
+      ? req.data.customerId.replace(/-/g, '')
+      : req.data.codeAccount.replace(/-/g, '')
     const endpoint = `${host}/api/v1/google-ads/${accountId}`
     if (req.data.customerId) {
       onAuthedReq(endpoint, updateUi)
@@ -150,11 +152,10 @@ function onAuthedReq(endpoint, cb, includeLocations = false) {
       url: `${endpoint}?key=${res.apiKey}`,
       headers
     })
-
     const client = await getClientFromUrn(data.clientUrn)
     const locations = await getLocations(client.urn)
-
     const { locationUrn } = data
+    console.log(includeLocations)
     if (includeLocations) {
       const selectedLocations = locations.filter(l => l.urn === locationUrn)
       cb({ client, locations, selectedLocations })
@@ -173,7 +174,7 @@ function createNote(annotation) {
 }
 
 async function autoDetectClientLocation(url, cb, manual = false) {
-if (/https:\/\/www.g5search.com\/admin\/services\?id=(\d*)$/.test(url)) {
+  if (/https:\/\/www.g5search.com\/admin\/services\?id=(\d*)$/.test(url)) {
     const regex = /https:\/\/www.g5search.com\/admin\/services\?id=(\d*)$/
     const [, clientId] = url.match(regex)
     const endpoint = `${host}/api/core/client/${clientId}`

--- a/src/content-scripts/google-ads.js
+++ b/src/content-scripts/google-ads.js
@@ -8,7 +8,6 @@
     }
     codeAccount = opId.innerText;
   }
-  console.log({ codeAccount, customerId });
   chrome.runtime.sendMessage({
     msg: 'google-ads',
     data: { codeAccount, customerId }

--- a/src/content-scripts/google-ads.js
+++ b/src/content-scripts/google-ads.js
@@ -1,11 +1,8 @@
 (function() {
-  let codeAccount, customerId;
+  let codeAccount = '', customerId;
   const exId = document.querySelector('div.external-customer-id');
   const opId = document.querySelector('div.operating-customer > .id');
-  if (!opId) {
-    codeAccount = '';
-    // customerId = undefined;
-  } else {
+  if(opId) {
     if (exId) {
       customerId = exId.innerText;
     }


### PR DESCRIPTION
This updates the id used for auto-populating the client in Google Ads when a location is not selected. The customerID is now used to query the budget_campain table for a urn at the client level rather than the codeAccount.