### PR TITLE
Auto detect G5 websites

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "annotation-extension",
-  "version": "1.3.21",
+  "version": "1.3.22",
   "description": "A Vue-based Chrome Extension for G5 COPS annotation service.",
   "author": "David Miller, Tyler Hasenoehrl, Colin McCullough",
   "engines": {

--- a/src/background.js
+++ b/src/background.js
@@ -1,149 +1,164 @@
-import axios from 'axios'
-import store from './store'
-import { AutoDetecter } from './controllers/AutoDetectClass'
+import axios from "axios";
+import store from "./store";
+import { AutoDetecter } from "./controllers/AutoDetectClass";
 
-const host = 'https://notes.g5marketingcloud.com'
-// const host = 'http://localhost:3000'
+// const host = "https://notes.g5marketingcloud.com";
+const host = 'http://localhost:3000'
 
 const headers = {
-  'Accept': 'application/json',
-  'Content-Type': 'application/json',
-  'Access-Control-Allow-Headers': '*',
-  'Access-Control-Allow-Origin': ''
-}
+  Accept: "application/json",
+  "Content-Type": "application/json",
+  "Access-Control-Allow-Headers": "*",
+  "Access-Control-Allow-Origin": "",
+};
 
 chrome.runtime.onInstalled.addListener(async () => {
-  const clients = await getClients()
-  await store.dispatch('setClients', clients)
-  chrome.storage.sync.get('apiKey', (res) => {
+  const clients = await getClients();
+  await store.dispatch("setClients", clients);
+  chrome.storage.sync.get("apiKey", (res) => {
     if (res.apiKey) {
-      store.dispatch('hasToken')
+      store.dispatch("hasToken");
     } else {
-      console.log('%c No apiKey Found!', 'color: red;')
+      console.log("%c No apiKey Found!", "color: red;");
     }
-  })
-})
+  });
+});
 
-chrome.runtime.onMessage.addListener(onMessage)
+chrome.runtime.onMessage.addListener(onMessage);
 
 async function onMessage(req, sender, res) {
-  if (req.msg === 'locations') {
-    getXHRLocations(req.data.value, res)
-  } else if (req.msg === 'login') {
-    const key = await getApiKey(req.email)
+  if (req.msg === "locations") {
+    getXHRLocations(req.data.value, res);
+  } else if (req.msg === "login") {
+    const key = await getApiKey(req.email);
     chrome.storage.sync.set({ apiKey: key }, async () => {
-      await store.dispatch('hasToken')
-      res(201)
-    })
-  } else if (req.msg === 'set-team') {
+      await store.dispatch("hasToken");
+      res(201);
+    });
+  } else if (req.msg === "set-team") {
     chrome.storage.sync.set({ team: req.data }, async () => {
-      await store.dispatch('setTeam', req.data)
-      res(201)
-    })
-  } else if (req.msg === 'reload-clients') {
-    getXHRClients(res)
-  } else if (req.msg === 'create-note') {
-    createNote(req.data)
-    res(201)
-  } else if (req.msg === 'auto-detect') {
-    const { manual } = req
-    const autoDetect = new AutoDetecter(req.url, res, manual)
-    await autoDetect.detect()
-  } else if (req.msg === 'core') {
-    const clientId = req.data.clientId
+      await store.dispatch("setTeam", req.data);
+      res(201);
+    });
+  } else if (req.msg === "reload-clients") {
+    getXHRClients(res);
+  } else if (req.msg === "create-note") {
+    createNote(req.data);
+    res(201);
+  } else if (req.msg === "auto-detect") {
+    const { manual } = req;
+    const autoDetect = new AutoDetecter(req.url, res, manual);
+    await autoDetect.detect();
+  } else if (req.msg === 'g5-website') {
+    const { clientUrn, locationUrn } = req.data;
+    const client = await getClientFromUrn(clientUrn);
+    const locations = await getLocations(clientUrn);
+    const selectedLocations = locations.filter((l) => l.urn === locationUrn);
+    const team = store.state.team.payload;
+    const corp = selectedLocations[0].corporate;
+    corp === 'true' && team === 'da' ?
+      updateUi({ client, locations }) :
+      updateUi({ client, locations, selectedLocations });
+    res(200);
+  } else if (req.msg === "core") {
+    const clientId = req.data.clientId;
     if (clientId) {
-      const endpoint = `${host}/api/core/client/${clientId}`
-      onAuthedReq(endpoint, updateUi)
+      const endpoint = `${host}/api/core/client/${clientId}`;
+      onAuthedReq(endpoint, updateUi);
     }
-  } else if (req.msg === 'google-ads') {
+  } else if (req.msg === "google-ads") {
     const accountId = req.data.customerId
-      ? req.data.customerId.replace(/-/g, '')
-      : req.data.codeAccount.replace(/-/g, '')
-    const endpoint = `${host}/api/v1/google-ads/${accountId}`
+      ? req.data.customerId.replace(/-/g, "")
+      : req.data.codeAccount.replace(/-/g, "");
+    const endpoint = `${host}/api/v1/google-ads/${accountId}`;
     if (req.data.customerId) {
-      onAuthedReq(endpoint, updateUi)
+      onAuthedReq(endpoint, updateUi);
     } else {
-      onAuthedReq(endpoint, updateUi, true)
+      onAuthedReq(endpoint, updateUi, true);
     }
-    res(201)
-  } else if (req.msg === 'shape') {
-    const { urn } = req.data
-    if (urn.startsWith('g5-cl')) {
-      const endpoint = `${host}/api/hub/location/${urn}`
-      onAuthedReq(endpoint, updateUi, true)
+    res(201);
+  } else if (req.msg === "shape") {
+    const { urn } = req.data;
+    if (urn.startsWith("g5-cl")) {
+      const endpoint = `${host}/api/hub/location/${urn}`;
+      onAuthedReq(endpoint, updateUi, true);
     } else {
-      const client = await getClientFromUrn(urn)
-      const locations = await getLocations(urn)
-      updateUi({ client, locations })
+      const client = await getClientFromUrn(urn);
+      const locations = await getLocations(urn);
+      updateUi({ client, locations });
     }
-    res(200)
+    res(200);
   }
 }
 
 function updateUi(data) {
   chrome.runtime.sendMessage({
-    msg: 'update-ui',
-    data
-  })
+    msg: "update-ui",
+    data,
+  });
 }
 
 async function getClients() {
   const clients = await axios({
-    method: 'GET',
+    method: "GET",
     url: `${host}/api/hub/clients?activeDa=false&internal=false`,
-    headers
-  })
-  return clients.data
+    headers,
+  });
+  return clients.data;
 }
 
 async function getClientFromUrn(urn) {
-  const clients = store.getters.clients
-  const client = clients.filter(client => client.urn == urn)
-  return client[0]
+  const clients = store.getters.clients;
+  const client = clients.filter((client) => client.urn == urn);
+  return client[0];
 }
 
 function getXHRClients(cb) {
-  const xhr = new XMLHttpRequest()
-  xhr.open('GET', `${host}/api/hub/clients?activeDa=false&internal=false`, true)
-  xhr.setRequestHeader('Content-Type', 'application/json')
-  xhr.send()
+  const xhr = new XMLHttpRequest();
+  xhr.open(
+    "GET",
+    `${host}/api/hub/clients?activeDa=false&internal=false`,
+    true
+  );
+  xhr.setRequestHeader("Content-Type", "application/json");
+  xhr.send();
   xhr.onload = () => {
-    const clients = JSON.parse(xhr.responseText)
-    store.dispatch('setClients', clients)
-    cb(200)
-  }
+    const clients = JSON.parse(xhr.responseText);
+    store.dispatch("setClients", clients);
+    cb(200);
+  };
 }
 
 function getXHRLocations(urn, cb) {
-  const xhr = new XMLHttpRequest()
-  xhr.open('GET', `${host}/api/hub/clients/${urn}/locations`, true)
-  xhr.setRequestHeader('Content-Type', 'application/json')
-  xhr.send()
+  const xhr = new XMLHttpRequest();
+  xhr.open("GET", `${host}/api/hub/clients/${urn}/locations`, true);
+  xhr.setRequestHeader("Content-Type", "application/json");
+  xhr.send();
   xhr.onload = () => {
-    const locations = JSON.parse(xhr.responseText)
-    const filtered = locations.filter(l => l.status !== 'Deleted')
-    cb({ locations: filtered })
-    updateUi({ locations: filtered })
-  }
+    const locations = JSON.parse(xhr.responseText);
+    const filtered = locations.filter((l) => l.status !== "Deleted");
+    cb({ locations: filtered });
+    updateUi({ locations: filtered });
+  };
 }
 
 async function getLocations(urn) {
   const locations = await axios({
-    method: 'GET',
+    method: "GET",
     url: `${host}/api/hub/clients/${urn}/locations`,
-    headers
-  })
-  return locations.data.filter(l => l.status !== 'Deleted')
+    headers,
+  });
+  return locations.data.filter((l) => l.status !== "Deleted");
 }
 
 async function getApiKey(email) {
   const { data } = await axios({
-    method: 'POST',
+    method: "POST",
     url: `${host}/api/v1/key`,
     headers,
-    data: { email }
-  })
-  return data.key
+    data: { email },
+  });
+  return data.key;
 }
 
 /**
@@ -152,39 +167,34 @@ async function getApiKey(email) {
  * @param {Boolean} includeLocations
  */
 function onAuthedReq(endpoint, cb, includeLocations = false) {
-  chrome.storage.sync.get('apiKey', async (res) => {
+  chrome.storage.sync.get("apiKey", async (res) => {
     if (!res.apiKey) {
-      cb(404)
-      return
+      cb(404);
+      return;
     }
     const { data } = await axios({
-      method: 'GET',
+      method: "GET",
       url: `${endpoint}?key=${res.apiKey}`,
-      headers
-    })
-    const client = await getClientFromUrn(data.clientUrn)
-    const locations = await getLocations(client.urn)
-    const { locationUrn } = data
+      headers,
+    });
+    const client = await getClientFromUrn(data.clientUrn);
+    const locations = await getLocations(client.urn);
+    const { locationUrn } = data;
     if (includeLocations) {
-      const selectedLocations = locations.filter(l => l.urn === locationUrn)
-      cb({ client, locations, selectedLocations })
-      updateUi({ client, locations, selectedLocations })
+      const selectedLocations = locations.filter((l) => l.urn === locationUrn);
+      cb({ client, locations, selectedLocations });
+      updateUi({ client, locations, selectedLocations });
     } else {
-      cb({ client, locations })
-      updateUi({ client, locations })
+      cb({ client, locations });
+      updateUi({ client, locations });
     }
-  })
+  });
 }
 
 function createNote(annotation) {
-  chrome.storage.sync.get('apiKey', (res) => {
-    axios.post(`${host}/api/v1/note?key=${res.apiKey}`, annotation)
-  })
+  chrome.storage.sync.get("apiKey", (res) => {
+    axios.post(`${host}/api/v1/note?key=${res.apiKey}`, annotation);
+  });
 }
 
-export {
-  onAuthedReq,
-  updateUi,
-  getLocations,
-  getClientFromUrn
-}
+export { onAuthedReq, updateUi, getLocations, getClientFromUrn };

--- a/src/background.js
+++ b/src/background.js
@@ -2,8 +2,8 @@ import axios from "axios";
 import store from "./store";
 import { AutoDetecter } from "./controllers/AutoDetectClass";
 
-// const host = "https://notes.g5marketingcloud.com";
-const host = 'http://localhost:3000'
+const host = "https://notes.g5marketingcloud.com";
+// const host = 'http://localhost:3000'
 
 const headers = {
   Accept: "application/json",

--- a/src/content-scripts/clw.js
+++ b/src/content-scripts/clw.js
@@ -1,4 +1,19 @@
-(function() {
-  // const dataLayer = window.dataLayer
-  console.log(window.dataLayer)
-})()
+(function () {
+  let clientUrn = null
+  let locationUrn = null
+  const scripts = document.querySelectorAll('head script[type="text/javascript"]');
+  const scriptsArr = Array.from(scripts);
+  const node = scriptsArr.find((script) => {
+    return script.innerHTML.includes('G5_CLIENT_ID')
+  })
+  if (node) {
+    const html = node.innerHTML
+    const dataLayer = JSON.parse(html.substring(html.indexOf('{'), html.lastIndexOf('}') + 1));
+    clientUrn = dataLayer.G5_CLIENT_ID
+    locationUrn = dataLayer.G5_STORE_ID
+    chrome.runtime.sendMessage({
+      msg: "g5-website",
+      data: { clientUrn, locationUrn },
+    });
+  }
+})();

--- a/src/controllers/AutoDetectClass.js
+++ b/src/controllers/AutoDetectClass.js
@@ -1,5 +1,10 @@
-import { onAuthedReq, updateUi, getLocations, getClientFromUrn } from '../background'
-import { pageMap } from '../config/pageDetection'
+import {
+  onAuthedReq,
+  updateUi,
+  getLocations,
+  getClientFromUrn,
+} from "../background";
+import { pageMap } from "../config/pageDetection";
 
 /**
  * Class auto populates client and location in extensions ui
@@ -13,57 +18,56 @@ class AutoDetecter {
    * @param {function} cb - callback funtion to res chrome msg
    */
   constructor(url, cb, manual = false) {
-    this.url = url
-    this.manual = manual
-    this.cb = cb
-    this.pageMap = pageMap
+    this.url = url;
+    this.manual = manual;
+    this.cb = cb;
+    this.pageMap = pageMap;
   }
 
   fromUrl(regexStr, data) {
-    const id = this.url.match(new RegExp(regexStr))[data.group]
-    const endpoint = `${data.host}${id}`
-    onAuthedReq(endpoint, this.cb, data.selectLocation)
+    const id = this.url.match(new RegExp(regexStr))[data.group];
+    const endpoint = `${data.host}${id}`;
+    onAuthedReq(endpoint, this.cb, data.selectLocation);
   }
 
   injected(regexStr, data) {
     chrome.tabs.executeScript({
-      file: data.file
-    })
-    this.cb({ status: 200 })
+      file: data.file,
+    });
+    this.cb({ status: 200 });
   }
 
   async populateClientAndLoc(regexStr, data) {
-    const [, clientUrn, locationUrn] = this.url.match(new RegExp(regexStr))
-    const client = await getClientFromUrn(clientUrn)
-    const locations = await getLocations(clientUrn)
-    const selectedLocations = locations.filter(l => l.urn === locationUrn)
-    this.cb({ client, locations, selectedLocations })
-    updateUi({ client, locations, selectedLocations })
+    const [, clientUrn, locationUrn] = this.url.match(new RegExp(regexStr));
+    const client = await getClientFromUrn(clientUrn);
+    const locations = await getLocations(clientUrn);
+    const selectedLocations = locations.filter((l) => l.urn === locationUrn);
+    this.cb({ client, locations, selectedLocations });
+    updateUi({ client, locations, selectedLocations });
   }
 
   async populateClient(regexStr, data) {
-    const [, clientUrn] = this.url.match(new RegExp(regexStr))
-    const client = await getClientFromUrn(clientUrn)
-    const locations = await getLocations(client.urn)
-    this.cb({ client, locations })
-    updateUi({ client, locations })
+    const [, clientUrn] = this.url.match(new RegExp(regexStr));
+    const client = await getClientFromUrn(clientUrn);
+    const locations = await getLocations(client.urn);
+    this.cb({ client, locations });
+    updateUi({ client, locations });
   }
 
   detect() {
     const matchVal = Object.entries(this.pageMap).filter(([key, val]) => {
       const reg = new RegExp(key);
-      return reg.test(this.url)
-    })
+      return reg.test(this.url);
+    });
+    console.log(matchVal);
     if (matchVal.length > 0) {
-      const [[regex, data]] = matchVal
-      this[data.functionName](regex, data)
+      const [[regex, data]] = matchVal;
+      this[data.functionName](regex, data);
     } else {
-      this.manual ? chrome.tabs.executeScript({file: './content-scripts/clw.js'})
-        : this.cb({ status: 200 })
+      // check if its a G5 website
+      this.injected("", { file: "./content-scripts/clw.js" });
     }
   }
 }
 
-export {
-  AutoDetecter
-}
+export { AutoDetecter };

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "annotation-extension",
   "description": "A Vue-based Chrome Extension for G5 COPS annotation service.",
-  "version": "1.3.21",
+  "version": "1.3.22",
   "manifest_version": 2,
   "icons": {
     "16": "icons/icon_16.png",


### PR DESCRIPTION
This merge will auto-populate the client/location drop down in the extension on g5 websites. If the user is on a corporate location and their team is set to 'da', only the client will auto-populate. All other teams will have the client and location populate on a corporate website. 

Test Examples:
Corp: https://www.aaastorage4u.com/
- Expected outcome: Client auto-populated if DA team selected. Client and location auto-populated if SEO team selected.

Location: https://www.aaastorage4u.com/self-storage/nc/browns-summit/aaa-self-storage-9/
- Expected outcome: Client and location auto-populated if regardless of team selection.

**Note:** The notes service app will need to have its branch 'added corp field to g5 updatable get model' merged to master before this branch is merged so the corporate field is available from the api call https://notes.g5marketingcloud.com/api/hub/clients/${urn}/locations.
